### PR TITLE
Fix packaging bug (PackageLoader fails to init)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ necessary Fortran code to interface it to the fortran-tf-lib.
     ],
     entry_points={
         'console_scripts': [
-            'process_model = process_model.process_model:main',
+            'process_model = process_model:main',
         ],
     },
+    package_data={'process_model': ['templates/*.F90']},
 )


### PR DESCRIPTION
If you don't include the templates directory in the package then when you try to initialise the Jinja Loader it fails somewhat cryptically with
`ValueError: The 'process_model' package was not installed in a way that PackageLoader understands.`

This does not occur if `pip install -e process_model/` was used.

The fix is to include the templates in the package.

Fixes #5